### PR TITLE
Passing test for bug 1

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -58,7 +58,8 @@ class App
           if !@projects || @projects.size == 0
             @output_stream.puts("\e[40;38;5;214mCan't edit any projects\e[0m")
             @output_stream.puts("\e[40;38;5;214mNo projects created\e[0m\n\n")
-            break
+            command = @input_stream.gets.chomp
+            next
           end
 
           @output_stream.puts("\e[0;35mEnter a project name:\e[0m")


### PR DESCRIPTION
App would unexpectedly quit when trying to edit a project that doesn't exist, or when no projects existed at all. This change now allows the user to continue using the app.